### PR TITLE
Remove unsupported CORRIMUDATA test.

### DIFF
--- a/novatel_gps_driver/test/novatel_gps_tests.cpp
+++ b/novatel_gps_driver/test/novatel_gps_tests.cpp
@@ -53,35 +53,6 @@ TEST(NovatelGpsTestSuite, testGpsFixParsing)
   ASSERT_EQ(40, fix_messages.size());
 }
 
-TEST(NovatelGpsTestSuite, testCorrImuDataParsing)
-{
-  novatel_gps_driver::NovatelGps gps;
-
-  std::string path = ros::package::getPath("novatel_gps_driver");
-  ASSERT_TRUE(gps.Connect(path + "/test/corrimudata.pcap", novatel_gps_driver::NovatelGps::PCAP));
-
-  std::vector<novatel_gps_msgs::NovatelCorrectedImuDataPtr> imu_messages;
-
-  while (gps.IsConnected() && gps.ProcessData() == novatel_gps_driver::NovatelGps::READ_SUCCESS)
-  {
-    std::vector<novatel_gps_msgs::NovatelCorrectedImuDataPtr> tmp_messages;
-    gps.GetNovatelCorrectedImuData(tmp_messages);
-    imu_messages.insert(imu_messages.end(), tmp_messages.begin(), tmp_messages.end());
-  }
-
-  ASSERT_EQ(26, imu_messages.size());
-
-  novatel_gps_msgs::NovatelCorrectedImuDataPtr msg = imu_messages.front();
-  EXPECT_EQ(1820, msg->gps_week_num);
-  EXPECT_DOUBLE_EQ(160205.899999999994, msg->gps_seconds);
-  EXPECT_DOUBLE_EQ(0.0000039572689929003956, msg->pitch_rate);
-  EXPECT_DOUBLE_EQ(0.0000028926313702935847, msg->roll_rate);
-  EXPECT_DOUBLE_EQ(0.0000027924848999730557, msg->yaw_rate);
-  EXPECT_DOUBLE_EQ(-0.00062560456243879322, msg->lateral_acceleration);
-  EXPECT_DOUBLE_EQ(0.00034037959880710289, msg->longitudinal_acceleration);
-  EXPECT_DOUBLE_EQ(-0.0000051257464089797534, msg->vertical_acceleration);
-}
-
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "novatel_gps_test_suite", ros::init_options::AnonymousName);


### PR DESCRIPTION
Removed failing test case that was based on replaying
a binary file containing CORRIMUDATA messages.

In the Ascent fork of the Novatel GPS driver,
we no longer support the CORRIMUDATA message type
and replaced it with a parser for IMURATECORRIMUS.

(Side note - should consider in the future generating a new binary file containing data for a IMURATECORRIMUS test. But I wanted to get this change in so we can at least add running the tests to our Jenkins build and have it pass. With this fix and the other PR for fixing test build in car_sensor_calibrations (https://github.com/ascentai/car_sensor_calibrations/pull/11), catkin_make run_tests passes in ascent_car. Will need one more PR to update subrepo versions in ascent_car after this.)