### PR TITLE
Fix message generation dependency.

### DIFF
--- a/novatel_gps_driver/CMakeLists.txt
+++ b/novatel_gps_driver/CMakeLists.txt
@@ -69,6 +69,7 @@ add_library(${PROJECT_NAME}
   src/parsers/trackstat.cpp
 )
 add_dependencies(${PROJECT_NAME} novatel_gps_msgs_generate_messages_cpp)
+add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}


### PR DESCRIPTION
-Added explicit dependency on catkin_EXPORTED_TARGETS
to ensure gps_common message generation precedes
building this package.

This came up because in ascent_car we build gps_common from source (and thus, have a dependency on message generation), whereas the novatel driver maintainers just pull this message definition from the ros deps. Causes intermittent failures during multithreaded catkin_make e.g. https://jenkins.ascentrobotics.jp/blue/organizations/jenkins/garage_manager/detail/PR-214/1/pipeline

Fix can be verified by in ascent_car workspace, delete ./build and ./devel, then try to build just this package ```catkin_make --pkg novatel_gps_driver```